### PR TITLE
Cache JsonProvider.provider() result as per javadoc recommendation

### DIFF
--- a/api/src/main/java/javax/json/Json.java
+++ b/api/src/main/java/javax/json/Json.java
@@ -25,6 +25,7 @@ import java.math.BigInteger;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
+
 import javax.json.spi.JsonProvider;
 import javax.json.stream.JsonGenerator;
 import javax.json.stream.JsonGeneratorFactory;
@@ -57,7 +58,8 @@ import javax.json.stream.JsonParserFactory;
  * threads.
  */
 public final class Json {
-
+	static final JsonProvider PROVIDER = JsonProvider.provider();
+	
     private Json() {
     }
 
@@ -68,7 +70,7 @@ public final class Json {
      * @return a JSON parser
      */
     public static JsonParser createParser(Reader reader) {
-        return JsonProvider.provider().createParser(reader);
+        return PROVIDER.createParser(reader);
     }
 
     /**
@@ -82,7 +84,7 @@ public final class Json {
      * @return a JSON parser
      */
     public static JsonParser createParser(InputStream in) {
-        return JsonProvider.provider().createParser(in);
+        return PROVIDER.createParser(in);
     }
 
     /**
@@ -92,7 +94,7 @@ public final class Json {
      * @return a JSON generator
      */
     public static JsonGenerator createGenerator(Writer writer) {
-        return JsonProvider.provider().createGenerator(writer);
+        return PROVIDER.createGenerator(writer);
     }
 
     /**
@@ -102,7 +104,7 @@ public final class Json {
      * @return a JSON generator
      */
     public static JsonGenerator createGenerator(OutputStream out) {
-        return JsonProvider.provider().createGenerator(out);
+        return PROVIDER.createGenerator(out);
     }
 
     /**
@@ -111,7 +113,7 @@ public final class Json {
      * @return JSON parser factory.
      *
     public static JsonParserFactory createParserFactory() {
-        return JsonProvider.provider().createParserFactory();
+        return PROVIDER.createParserFactory();
     }
      */
 
@@ -126,7 +128,7 @@ public final class Json {
      * @return JSON parser factory
      */
     public static JsonParserFactory createParserFactory(Map<String, ?> config) {
-        return JsonProvider.provider().createParserFactory(config);
+        return PROVIDER.createParserFactory(config);
     }
 
     /**
@@ -135,7 +137,7 @@ public final class Json {
      * @return JSON generator factory
      *
     public static JsonGeneratorFactory createGeneratorFactory() {
-        return JsonProvider.provider().createGeneratorFactory();
+        return PROVIDER.createGeneratorFactory();
     }
     */
 
@@ -151,7 +153,7 @@ public final class Json {
      */
     public static JsonGeneratorFactory createGeneratorFactory(
             Map<String, ?> config) {
-        return JsonProvider.provider().createGeneratorFactory(config);
+        return PROVIDER.createGeneratorFactory(config);
     }
 
     /**
@@ -163,7 +165,7 @@ public final class Json {
      * @return a JSON writer
      */
     public static JsonWriter createWriter(Writer writer) {
-        return JsonProvider.provider().createWriter(writer);
+        return PROVIDER.createWriter(writer);
     }
 
     /**
@@ -176,7 +178,7 @@ public final class Json {
      * @return a JSON writer
      */
     public static JsonWriter createWriter(OutputStream out) {
-        return JsonProvider.provider().createWriter(out);
+        return PROVIDER.createWriter(out);
     }
 
     /**
@@ -186,7 +188,7 @@ public final class Json {
      * @return a JSON reader
      */
     public static JsonReader createReader(Reader reader) {
-        return JsonProvider.provider().createReader(reader);
+        return PROVIDER.createReader(reader);
     }
 
     /**
@@ -198,7 +200,7 @@ public final class Json {
      * @return a JSON reader
      */
     public static JsonReader createReader(InputStream in) {
-        return JsonProvider.provider().createReader(in);
+        return PROVIDER.createReader(in);
     }
 
     /**
@@ -212,7 +214,7 @@ public final class Json {
      * @return a JSON reader factory
      */
     public static JsonReaderFactory createReaderFactory(Map<String, ?> config) {
-        return JsonProvider.provider().createReaderFactory(config);
+        return PROVIDER.createReaderFactory(config);
     }
 
     /**
@@ -226,7 +228,7 @@ public final class Json {
      * @return a JSON writer factory
      */
     public static JsonWriterFactory createWriterFactory(Map<String, ?> config) {
-        return JsonProvider.provider().createWriterFactory(config);
+        return PROVIDER.createWriterFactory(config);
     }
 
     /**
@@ -235,7 +237,7 @@ public final class Json {
      * @return a JSON array builder
      */
     public static JsonArrayBuilder createArrayBuilder() {
-        return JsonProvider.provider().createArrayBuilder();
+        return PROVIDER.createArrayBuilder();
     }
 
     /**
@@ -247,7 +249,7 @@ public final class Json {
      * @since 1.1
      */
     public static JsonArrayBuilder createArrayBuilder(JsonArray array) {
-        return JsonProvider.provider().createArrayBuilder(array);
+        return PROVIDER.createArrayBuilder(array);
     }
 
     /**
@@ -263,7 +265,7 @@ public final class Json {
      * @since 1.1
      */
     public static JsonArrayBuilder createArrayBuilder(Collection<?> collection) {
-        return JsonProvider.provider().createArrayBuilder(collection);
+        return PROVIDER.createArrayBuilder(collection);
     }
 
     /**
@@ -272,7 +274,7 @@ public final class Json {
      * @return a JSON object builder
      */
     public static JsonObjectBuilder createObjectBuilder() {
-        return JsonProvider.provider().createObjectBuilder();
+        return PROVIDER.createObjectBuilder();
     }
 
     /**
@@ -284,7 +286,7 @@ public final class Json {
      * @since 1.1
      */
     public static JsonObjectBuilder createObjectBuilder(JsonObject object) {
-        return JsonProvider.provider().createObjectBuilder(object);
+        return PROVIDER.createObjectBuilder(object);
     }
 
     /**
@@ -300,7 +302,7 @@ public final class Json {
      * @since 1.1
      */
     public static JsonObjectBuilder createObjectBuilder(Map<String, Object> map) {
-        return JsonProvider.provider().createObjectBuilder(map);
+        return PROVIDER.createObjectBuilder(map);
     }
 
     /**
@@ -319,7 +321,7 @@ public final class Json {
      * @since 1.1
      */
     public static JsonPointer createPointer(String jsonPointer) {
-        return JsonProvider.provider().createPointer(jsonPointer);
+        return PROVIDER.createPointer(jsonPointer);
     }
 
     /**
@@ -330,7 +332,7 @@ public final class Json {
      * @since 1.1
      */
     public static JsonPatchBuilder createPatchBuilder() {
-        return JsonProvider.provider().createPatchBuilder();
+        return PROVIDER.createPatchBuilder();
     }
 
     /**
@@ -344,7 +346,7 @@ public final class Json {
      * @since 1.1
      */
     public static JsonPatchBuilder createPatchBuilder(JsonArray array) {
-        return JsonProvider.provider().createPatchBuilder(array);
+        return PROVIDER.createPatchBuilder(array);
     }
 
     /**
@@ -357,7 +359,7 @@ public final class Json {
      * @since 1.1
      */
     public static JsonPatch createPatch(JsonArray array) {
-        return JsonProvider.provider().createPatch(array);
+        return PROVIDER.createPatch(array);
     }
 
     /**
@@ -372,7 +374,7 @@ public final class Json {
      * @since 1.1
      */
     public static JsonPatch createDiff(JsonStructure source, JsonStructure target) {
-        return JsonProvider.provider().createDiff(source, target);
+        return PROVIDER.createDiff(source, target);
     }
 
     /**
@@ -385,7 +387,7 @@ public final class Json {
      * @since 1.1
      */
     public static JsonMergePatch createMergePatch(JsonValue patch) {
-        return JsonProvider.provider().createMergePatch(patch);
+        return PROVIDER.createMergePatch(patch);
     }
 
     /**
@@ -400,7 +402,7 @@ public final class Json {
      * @since 1.1
      */
     public static JsonMergePatch createMergeDiff(JsonValue source, JsonValue target) {
-        return JsonProvider.provider().createMergeDiff(source, target);
+        return PROVIDER.createMergeDiff(source, target);
     }
 
     /**
@@ -416,7 +418,7 @@ public final class Json {
      */
     public static JsonBuilderFactory createBuilderFactory(
             Map<String, ?> config) {
-        return JsonProvider.provider().createBuilderFactory(config);
+        return PROVIDER.createBuilderFactory(config);
     }
 
     /**
@@ -428,7 +430,7 @@ public final class Json {
      * @since 1.1
      */
     public static JsonString createValue(String value) {
-        return JsonProvider.provider().createValue(value);
+        return PROVIDER.createValue(value);
     }
 
     /**
@@ -440,7 +442,7 @@ public final class Json {
      * @since 1.1
      */
     public static JsonNumber createValue(int value) {
-        return JsonProvider.provider().createValue(value);
+        return PROVIDER.createValue(value);
     }
 
     /**
@@ -452,7 +454,7 @@ public final class Json {
      * @since 1.1
      */
     public static JsonNumber createValue(long value) {
-        return JsonProvider.provider().createValue(value);
+        return PROVIDER.createValue(value);
     }
 
     /**
@@ -464,7 +466,7 @@ public final class Json {
      * @since 1.1
      */
     public static JsonNumber createValue(double value) {
-        return JsonProvider.provider().createValue(value);
+        return PROVIDER.createValue(value);
     }
 
     /**
@@ -476,7 +478,7 @@ public final class Json {
      * @since 1.1
      */
     public static JsonNumber createValue(BigDecimal value) {
-        return JsonProvider.provider().createValue(value);
+        return PROVIDER.createValue(value);
     }
 
     /**
@@ -488,7 +490,7 @@ public final class Json {
      * @since 1.1
      */
     public static JsonNumber createValue(BigInteger value) {
-        return JsonProvider.provider().createValue(value);
+        return PROVIDER.createValue(value);
     }
 
     /**


### PR DESCRIPTION
I got through this because I found a performance hostpot in calling Json methods (about 500 microsec per call on a i5)