### PR TITLE
'jakarta' groupId fix

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -27,8 +27,8 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <groupId>javax.json</groupId>
-    <artifactId>javax.json-api</artifactId>
+    <groupId>jakarta.json</groupId>
+    <artifactId>jakarta.json-api</artifactId>
     <packaging>bundle</packaging>
     <version>1.1.3-SNAPSHOT</version>
     <name>JSR 374 (JSON Processing) API</name>
@@ -83,6 +83,7 @@
                 <groupId>org.glassfish.build</groupId>
                 <artifactId>spec-version-maven-plugin</artifactId>
                 <configuration>
+                	<specMode>jakarta</specMode>
                     <spec>
                         <nonFinal>${non.final}</nonFinal>
                         <jarType>api</jarType>

--- a/bundles/ri/pom.xml
+++ b/bundles/ri/pom.xml
@@ -31,8 +31,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>

--- a/demos/customprovider-jdk9/pom.xml
+++ b/demos/customprovider-jdk9/pom.xml
@@ -76,8 +76,8 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/demos/facebook/pom.xml
+++ b/demos/facebook/pom.xml
@@ -36,8 +36,8 @@
             </activation>
             <dependencies>
                 <dependency>
-                    <groupId>javax.json</groupId>
-                    <artifactId>javax.json-api</artifactId>
+                    <groupId>jakarta.json</groupId>
+                    <artifactId>jakarta.json-api</artifactId>
                     <scope>compile</scope>
                 </dependency>
                 <dependency>

--- a/demos/jaxrs/pom.xml
+++ b/demos/jaxrs/pom.xml
@@ -38,8 +38,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/demos/jsonpointer/pom.xml
+++ b/demos/jsonpointer/pom.xml
@@ -36,8 +36,8 @@
             </activation>
             <dependencies>
                 <dependency>
-                    <groupId>javax.json</groupId>
-                    <artifactId>javax.json-api</artifactId>
+                    <groupId>jakarta.json</groupId>
+                    <artifactId>jakarta.json-api</artifactId>
                     <scope>compile</scope>
                 </dependency>
                 <dependency>

--- a/demos/pom.xml
+++ b/demos/pom.xml
@@ -38,8 +38,8 @@
                     <scope>provided</scope>
                 </dependency>
                 <dependency>
-                    <groupId>javax.json</groupId>
-                    <artifactId>javax.json-api</artifactId>
+                    <groupId>jakarta.json</groupId>
+                    <artifactId>jakarta.json-api</artifactId>
                     <scope>provided</scope>
                 </dependency>
             </dependencies>

--- a/demos/servlet/pom.xml
+++ b/demos/servlet/pom.xml
@@ -33,8 +33,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/gf/pom.xml
+++ b/gf/pom.xml
@@ -38,8 +38,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -105,8 +105,8 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/jaxrs-1x/pom.xml
+++ b/jaxrs-1x/pom.xml
@@ -74,8 +74,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -74,8 +74,8 @@
             <artifactId>javax.ws.rs-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
                 <plugin>
                     <groupId>org.glassfish.build</groupId>
                     <artifactId>spec-version-maven-plugin</artifactId>
-                    <version>1.2</version>
+                    <version>1.5</version>
                 </plugin>
                 <plugin>
                     <groupId>org.glassfish.copyright</groupId>
@@ -265,8 +265,8 @@
                 <version>7.0</version>
             </dependency>
             <dependency>
-                <groupId>javax.json</groupId>
-                <artifactId>javax.json-api</artifactId>
+                <groupId>jakarta.json</groupId>
+                <artifactId>jakarta.json-api</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -33,8 +33,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>


### PR DESCRIPTION
This PR changing API module groupId to `jakarta.json` and artifactId to `jakarta.json-api`. All project modules are updated. The spec-version plugin properly configured.