### PR TITLE
Fix infinite looping in skipArray/skipObject

### DIFF
--- a/api/src/main/java/javax/json/stream/JsonParser.java
+++ b/api/src/main/java/javax/json/stream/JsonParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -455,6 +455,11 @@ public interface JsonParser extends /*Auto*/Closeable {
      * the corresponding {@code END_ARRAY}.
      * If the parser is not in any array context, nothing happens.
      *
+     * @throws javax.json.JsonException if an i/o error occurs (IOException
+     * would be cause of JsonException)
+     * @throws JsonParsingException if the parser encounters invalid JSON
+     * when advancing to next state.
+     *
      * @since 1.1
      */
     default public void skipArray() {
@@ -468,6 +473,11 @@ public interface JsonParser extends /*Auto*/Closeable {
      * corresponding {@code END_OBJECT}, the parser is advanced to
      * the corresponding {@code END_OBJECT}.
      * If the parser is not in any object context, nothing happens.
+     *
+     * @throws javax.json.JsonException if an i/o error occurs (IOException
+     * would be cause of JsonException)
+     * @throws JsonParsingException if the parser encounters invalid JSON
+     * when advancing to next state.
      *
      * @since 1.1
      */

--- a/impl/src/main/java/org/glassfish/json/JsonParserImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonParserImpl.java
@@ -304,8 +304,10 @@ public class JsonParserImpl implements JsonParser {
         if (currentEvent != Event.START_OBJECT) {
             return;
         }
+        Event event = Event.START_OBJECT;
         while (hasNext()) {
-            switch (next()) {
+            event = next();
+            switch (event) {
             case START_ARRAY:
                 skipArray();
                 break;
@@ -318,7 +320,11 @@ public class JsonParserImpl implements JsonParser {
                 break;
             }
         }
-        throw parsingException(JsonToken.EOF, "[STRING, CURLYCLOSE]");
+        if (event == Event.KEY_NAME) {
+            throw parsingException(JsonToken.EOF, "[CURLYOPEN, SQUAREOPEN, STRING, NUMBER, TRUE, FALSE, NULL]");
+        } else {
+            throw parsingException(JsonToken.EOF, "[STRING, CURLYCLOSE]");
+        }
     }
 
     private JsonArray getArray(JsonArrayBuilder builder) {

--- a/impl/src/main/java/org/glassfish/json/JsonParserImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonParserImpl.java
@@ -501,6 +501,10 @@ public class JsonParserImpl implements JsonParser {
                     case CURLYOPEN:
                         depth++;
                         break;
+                    case EOF:
+                        throw parsingException(JsonToken.EOF, "[CURLYCLOSE]");
+                    default:
+                        break;
                 }
             } while (!(token == JsonToken.CURLYCLOSE && depth == 0));
         }
@@ -560,6 +564,10 @@ public class JsonParserImpl implements JsonParser {
                         break;
                     case SQUAREOPEN:
                         depth++;
+                        break;
+                    case EOF:
+                        throw parsingException(JsonToken.EOF, "[SQUARECLOSE]");
+                    default:
                         break;
                 }
             } while (!(token == JsonToken.SQUARECLOSE && depth == 0));

--- a/tests/src/test/java/org/glassfish/json/tests/JsonParserSkipTest.java
+++ b/tests/src/test/java/org/glassfish/json/tests/JsonParserSkipTest.java
@@ -19,6 +19,7 @@ package org.glassfish.json.tests;
 import java.io.StringReader;
 import javax.json.Json;
 import javax.json.stream.JsonParser;
+import javax.json.stream.JsonParsingException;
 import junit.framework.TestCase;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertFalse;
@@ -112,5 +113,23 @@ public class JsonParserSkipTest extends TestCase {
         assertEquals(JsonParser.Event.VALUE_NUMBER, parser.next());
         assertEquals(JsonParser.Event.END_OBJECT, parser.next());
         assertEquals(false, parser.hasNext());
+    }
+
+    public void testSkipArrayNotClosed() {
+        try (JsonParser parser = Json.createParser(new StringReader("["))) {
+            parser.next();
+            parser.skipArray();
+            fail();
+        } catch (JsonParsingException expected) {
+        }
+    }
+
+    public void testSkipObjectNotClosed() {
+        try (JsonParser parser = Json.createParser(new StringReader("{"))) {
+            parser.next();
+            parser.skipObject();
+            fail();
+        } catch (JsonParsingException expected) {
+        }
     }
 }


### PR DESCRIPTION
JSON array and objcet which are not properly closed cause infinite looping 
in JsonParser#skipArray() and JsonParser#skipObject() 

Signed-off-by: leadpony <dev@leadpony.org>