### PR TITLE
Update surefire version for customprovider-jdk9

### DIFF
--- a/demos/customprovider-jdk9/pom.xml
+++ b/demos/customprovider-jdk9/pom.xml
@@ -52,7 +52,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.20</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
The following command fails while building customprovider-jdk9 module due to old Maven Surefire plugin:

```
mvn -U -C -Pstaging clean install -Dnon.final=true
```

I updated the plugin to the version 2.22 as specified in pom.xml in the repository root.

Signed-off-by: leadpony <dev@leadpony.org>