### PR TITLE
Add 1.1.5 release information to EE4J_8 branch. Raise snapshot version.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -23,14 +23,14 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.1.5-SNAPSHOT</version>
+        <version>1.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>jakarta.json</groupId>
     <artifactId>jakarta.json-api</artifactId>
     <packaging>bundle</packaging>
-    <version>1.1.5-SNAPSHOT</version>
+    <version>1.1.5</version>
     <name>JSR 374 (JSON Processing) API</name>
     <description>API module of JSR 374:Java API for Processing JSON</description>
     <url>https://javaee.github.io/jsonp</url>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -23,14 +23,14 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.1.5</version>
+        <version>1.1.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>jakarta.json</groupId>
     <artifactId>jakarta.json-api</artifactId>
     <packaging>bundle</packaging>
-    <version>1.1.5</version>
+    <version>1.1.6-SNAPSHOT</version>
     <name>JSR 374 (JSON Processing) API</name>
     <description>API module of JSR 374:Java API for Processing JSON</description>
     <url>https://javaee.github.io/jsonp</url>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.1.5</version>
+        <version>1.1.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.1.5-SNAPSHOT</version>
+        <version>1.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bundles/ri/pom.xml
+++ b/bundles/ri/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json-bundles</artifactId>
-        <version>1.1.5</version>
+        <version>1.1.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>json-ri-bundle</artifactId>

--- a/bundles/ri/pom.xml
+++ b/bundles/ri/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json-bundles</artifactId>
-        <version>1.1.5-SNAPSHOT</version>
+        <version>1.1.5</version>
     </parent>
 
     <artifactId>json-ri-bundle</artifactId>

--- a/demos/customprovider-jdk9/pom.xml
+++ b/demos/customprovider-jdk9/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.5</version>
+        <version>1.1.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/customprovider-jdk9/pom.xml
+++ b/demos/customprovider-jdk9/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.5-SNAPSHOT</version>
+        <version>1.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/facebook/pom.xml
+++ b/demos/facebook/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.5</version>
+        <version>1.1.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/facebook/pom.xml
+++ b/demos/facebook/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.5-SNAPSHOT</version>
+        <version>1.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/jaxrs/pom.xml
+++ b/demos/jaxrs/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.5</version>
+        <version>1.1.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/jaxrs/pom.xml
+++ b/demos/jaxrs/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.5-SNAPSHOT</version>
+        <version>1.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/jsonpointer/pom.xml
+++ b/demos/jsonpointer/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.5</version>
+        <version>1.1.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/jsonpointer/pom.xml
+++ b/demos/jsonpointer/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.5-SNAPSHOT</version>
+        <version>1.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/pom.xml
+++ b/demos/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.1.5-SNAPSHOT</version>
+        <version>1.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/pom.xml
+++ b/demos/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.1.5</version>
+        <version>1.1.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/servlet/pom.xml
+++ b/demos/servlet/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.5</version>
+        <version>1.1.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/servlet/pom.xml
+++ b/demos/servlet/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.5-SNAPSHOT</version>
+        <version>1.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/twitter/pom.xml
+++ b/demos/twitter/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.5</version>
+        <version>1.1.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/twitter/pom.xml
+++ b/demos/twitter/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.5-SNAPSHOT</version>
+        <version>1.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/gf/customprovider/pom.xml
+++ b/gf/customprovider/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>providers</artifactId>
-        <version>1.1.5</version>
+        <version>1.1.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/gf/customprovider/pom.xml
+++ b/gf/customprovider/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>providers</artifactId>
-        <version>1.1.5-SNAPSHOT</version>
+        <version>1.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/gf/defaultprovider/pom.xml
+++ b/gf/defaultprovider/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>providers</artifactId>
-        <version>1.1.5</version>
+        <version>1.1.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/gf/defaultprovider/pom.xml
+++ b/gf/defaultprovider/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>providers</artifactId>
-        <version>1.1.5-SNAPSHOT</version>
+        <version>1.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/gf/pom.xml
+++ b/gf/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.1.5</version>
+        <version>1.1.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/gf/pom.xml
+++ b/gf/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.1.5-SNAPSHOT</version>
+        <version>1.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -23,14 +23,14 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.1.5-SNAPSHOT</version>
+        <version>1.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>org.glassfish</groupId>
     <artifactId>jakarta.json</artifactId>
     <packaging>bundle</packaging>
-    <version>1.1.5-SNAPSHOT</version>
+    <version>1.1.5</version>
     <name>JSR 374 (JSON Processing) Default Provider</name>
     <description>Default provider for JSR 374:Java API for Processing JSON</description>
     <url>https://javaee.github.io/jsonp</url>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -23,14 +23,14 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.1.5</version>
+        <version>1.1.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>org.glassfish</groupId>
     <artifactId>jakarta.json</artifactId>
     <packaging>bundle</packaging>
-    <version>1.1.5</version>
+    <version>1.1.6-SNAPSHOT</version>
     <name>JSR 374 (JSON Processing) Default Provider</name>
     <description>Default provider for JSR 374:Java API for Processing JSON</description>
     <url>https://javaee.github.io/jsonp</url>

--- a/jaxrs-1x/pom.xml
+++ b/jaxrs-1x/pom.xml
@@ -23,13 +23,13 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.1.5-SNAPSHOT</version>
+        <version>1.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>jsonp-jaxrs-1x</artifactId>
     <packaging>bundle</packaging>
-    <version>1.1.5-SNAPSHOT</version>
+    <version>1.1.5</version>
     <name>JSR 374 (JSON Processing) Media for JAX-RS 1.1</name>
     <description>JAX-RS 1.1 MessageBodyReader and MessageBodyWriter to support JsonObject/JsonArray/JsonStructure API of JSR 374:Java API for Processing JSON</description>
     <url>https://javaee.github.io/jsonp</url>

--- a/jaxrs-1x/pom.xml
+++ b/jaxrs-1x/pom.xml
@@ -23,13 +23,13 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.1.5</version>
+        <version>1.1.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>jsonp-jaxrs-1x</artifactId>
     <packaging>bundle</packaging>
-    <version>1.1.5</version>
+    <version>1.1.6-SNAPSHOT</version>
     <name>JSR 374 (JSON Processing) Media for JAX-RS 1.1</name>
     <description>JAX-RS 1.1 MessageBodyReader and MessageBodyWriter to support JsonObject/JsonArray/JsonStructure API of JSR 374:Java API for Processing JSON</description>
     <url>https://javaee.github.io/jsonp</url>

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -23,14 +23,14 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.1.5-SNAPSHOT</version>
+        <version>1.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>org.glassfish</groupId>
     <artifactId>jsonp-jaxrs</artifactId>
     <packaging>bundle</packaging>
-    <version>1.1.5-SNAPSHOT</version>
+    <version>1.1.5</version>
     <name>JSR 374 (JSON Processing) Media for JAX-RS</name>
     <description>JAX-RS MessageBodyReader and MessageBodyWriter to support JsonValue API of JSR 374:Java API for Processing JSON</description>
     <url>https://javaee.github.io/jsonp</url>

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -23,14 +23,14 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.1.5</version>
+        <version>1.1.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>org.glassfish</groupId>
     <artifactId>jsonp-jaxrs</artifactId>
     <packaging>bundle</packaging>
-    <version>1.1.5</version>
+    <version>1.1.6-SNAPSHOT</version>
     <name>JSR 374 (JSON Processing) Media for JAX-RS</name>
     <description>JAX-RS MessageBodyReader and MessageBodyWriter to support JsonValue API of JSR 374:Java API for Processing JSON</description>
     <url>https://javaee.github.io/jsonp</url>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <groupId>org.glassfish</groupId>
     <artifactId>json</artifactId>
     <packaging>pom</packaging>
-    <version>1.1.5</version>
+    <version>1.1.6-SNAPSHOT</version>
     <name>JSR 374 (JSON Processing) RI</name>
     <description>JSR 374:Java API for Processing JSON RI</description>
     <url>https://javaee.github.io/jsonp</url>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <groupId>org.glassfish</groupId>
     <artifactId>json</artifactId>
     <packaging>pom</packaging>
-    <version>1.1.5-SNAPSHOT</version>
+    <version>1.1.5</version>
     <name>JSR 374 (JSON Processing) RI</name>
     <description>JSR 374:Java API for Processing JSON RI</description>
     <url>https://javaee.github.io/jsonp</url>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.1.5</version>
+        <version>1.1.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.1.5-SNAPSHOT</version>
+        <version>1.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
I'm releasing JSON-P 1.1.5 to central based on it's status in https://docs.google.com/spreadsheets/d/18mv1Kx6w2AhHJQEP-Mump-3cxFHx4CnvWEHVAkc8ZgU/edit#gid=0

https://jenkins.eclipse.org/jsonp/job/nexus-staging/59/console job passed so release is done.
Now it's time to merge release branch to EE4J_8.