### PR TITLE
Add missing JsonPointer#toString in api/impl/tests

### DIFF
--- a/api/src/main/java/javax/json/JsonPointer.java
+++ b/api/src/main/java/javax/json/JsonPointer.java
@@ -113,4 +113,13 @@ public interface JsonPointer {
      * @throws JsonException if the referenced value does not exist
      */
     JsonValue getValue(JsonStructure target);
+
+    /**
+     * Returns the string representation of this JSON Pointer.
+     * The value to be returned is an empty string or a sequence of '{@code /}' prefixed tokens.
+     *
+     * @return the valid escaped JSON Pointer string.
+     */
+    @Override
+    String toString();
 }

--- a/impl/src/main/java/org/glassfish/json/JsonPointerImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonPointerImpl.java
@@ -197,6 +197,14 @@ public final class JsonPointerImpl implements JsonPointer, Serializable {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return jsonPointer;
+    }
+
+    /**
      * Executes the operation
      * @param op a {code BiFunction} used to specify the operation to execute on
      *    the leaf node of the Json Pointer

--- a/tests/src/test/java/org/glassfish/json/tests/JsonPointerToStringTest.java
+++ b/tests/src/test/java/org/glassfish/json/tests/JsonPointerToStringTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2015, 2017 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.json.tests;
+
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+
+import java.util.Arrays;
+
+import javax.json.Json;
+import javax.json.JsonPointer;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * JSON pointer toString tests.
+ *
+ * @author leadpony
+ */
+@RunWith(Parameterized.class)
+public class JsonPointerToStringTest {
+
+    @Parameters(name = "{index}: {0}")
+    public static Iterable<Object> data() {
+        return Arrays.asList("", "/", "/one/two/3", "/a~1b", "/m~0n");
+    }
+
+    private final String expected;
+
+    public JsonPointerToStringTest(String expected) {
+        this.expected = expected;
+    }
+
+    @Test
+    public void shouldReturnOriginalEscapedString() {
+        JsonPointer pointer = Json.createPointer(expected);
+        assertThat(pointer.toString(), is(equalTo(expected)));
+    }
+}


### PR DESCRIPTION
`JsonPointer` interface does not provide any way to return its original string representation.
Naturally, `toString` method should be overridden  instread of returning meaningless class name plus hash code. The API and the implementation are added with a test class in this PR.
Thank you.
Signed-off-by: leadpony <dev@leadpony.org>