### PR TITLE
Fix build failure with JDK 11.0.2.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -57,7 +57,7 @@
                         </group>
                     </groups>
                     <bottom>
-<![CDATA[Copyright &#169; 2012-2018,
+<![CDATA[Copyright &#169; 2012-2019,
     <a href="http://www.oracle.com">Oracle</a>
     and/or its affiliates. All Rights Reserved.
     Use is subject to

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -65,9 +65,6 @@
     <br>Comments to : jsonp-dev@eclipse.org
 ]]>
                     </bottom>
-                    <links>
-                        <link>http://docs.oracle.com/javase/8/docs/api/</link>
-                    </links>
                 </configuration>
 
                 <executions>

--- a/demos/customprovider-jdk9/pom.xml
+++ b/demos/customprovider-jdk9/pom.xml
@@ -52,7 +52,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.20</version>
                 <executions>
                     <execution>
                         <goals>

--- a/demos/customprovider-jdk9/pom.xml
+++ b/demos/customprovider-jdk9/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/pom.xml
+++ b/pom.xml
@@ -373,7 +373,6 @@
                             <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-compiler-plugin</artifactId>
                             <configuration>
-                                <source>8</source>
                                 <release>8</release>
                             </configuration>
                             <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
         <new_impl_version>1.2.0</new_impl_version>
         <non.final>false</non.final>
         <legal.doc.source>${maven.multiModuleProjectDirectory}</legal.doc.source>
+        <javadoc.link.jdk>http://docs.oracle.com/javase/8/docs/api</javadoc.link.jdk>
     </properties>
 
     <build>
@@ -178,6 +179,12 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>3.0.1</version>
+                    <configuration>
+                        <detectJavaApiLink>false</detectJavaApiLink>
+                        <links>
+                            <link>${javadoc.link.jdk}</link>
+                        </links>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -366,6 +373,7 @@
                             <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-compiler-plugin</artifactId>
                             <configuration>
+                                <source>8</source>
                                 <release>8</release>
                             </configuration>
                             <executions>
@@ -429,6 +437,16 @@
                 <module>demos</module>
                 <module>bundles</module>
             </modules>
+        </profile>
+
+        <profile>
+            <id>jdk11-setup</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <properties>
+                <javadoc.link.jdk>https://docs.oracle.com/en/java/javase/11/docs/api</javadoc.link.jdk>
+            </properties>
         </profile>
 
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at


### PR DESCRIPTION
The following build command described in README.md fails in JDK 11.0.2 while generating the Javadoc.
```bash
mvn -U -C clean install -Dnon.final=true
```
Travis CI now uses 11.0.2 when the `jdk` is specified as `openjdk11`.
This PR fixes this problem and I tested the build against oraclejdk8, openjdk9, openjdk10 and openjdk11.
Please note that this patch includes PR #148. 
Thank you.

Signed-off-by: leadpony <dev@leadpony.org>