### PR TITLE
Bug 169 : Operation path encoding as required by RFC6901

### DIFF
--- a/impl/src/main/java/org/glassfish/json/JsonPatchImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonPatchImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -224,14 +224,14 @@ public class JsonPatchImpl implements JsonPatch {
         private void diffObject(String path, JsonObject source, JsonObject target) {
             source.forEach((key, value) -> {
                 if (target.containsKey(key)) {
-                    diff(path + '/' + key, value, target.get(key));
+                    diff(path + '/' + Json.encodePointer(key), value, target.get(key));
                 } else {
-                    builder.remove(path + '/' + key);
+                    builder.remove(path + '/' + Json.encodePointer(key));
                 }
             });
             target.forEach((key, value) -> {
                 if (! source.containsKey(key)) {
-                    builder.add(path + '/' + key, value);
+                    builder.add(path + '/' + Json.encodePointer(key), value);
                 }
             });
         }

--- a/tests/src/test/java/org/glassfish/json/tests/JsonPatchDiffTest.java
+++ b/tests/src/test/java/org/glassfish/json/tests/JsonPatchDiffTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -50,8 +50,8 @@ public class JsonPatchDiffTest {
 
     @Parameters(name = "{index}: ({0})={1}")
     public static Iterable<Object[]> data() throws Exception {
-        List<Object[]> examples = new ArrayList<Object[]>();
-        JsonArray data = loadData();
+        List<Object[]> examples = new ArrayList<>();
+        JsonArray data = JsonPatchDiffTest.loadData();
         for (JsonValue jsonValue : data) {
             JsonObject test = (JsonObject) jsonValue;
             Object[] testData = new Object[4];
@@ -78,8 +78,12 @@ public class JsonPatchDiffTest {
     private static JsonArray loadData() {
         InputStream testData = JsonPatchTest.class
                 .getResourceAsStream("/jsonpatchdiff.json");
-        JsonReader reader = Json.createReader(testData);
-        JsonArray data = (JsonArray) reader.read();
+
+        JsonArray data;
+        try(JsonReader reader = Json.createReader(testData)){
+            data = (JsonArray) reader.read();
+        }
+
         return data;
     }
 

--- a/tests/src/test/resources/jsonpatchdiff.json
+++ b/tests/src/test/resources/jsonpatchdiff.json
@@ -156,5 +156,14 @@
                             { "path" : "/1", "value" : 1, "op" : "add" },
                             { "value" : 3, "op" : "add", "path" : "/3" }
                         ]
+        },
+        {
+          "original": {"a/b": "c", "e/f":  "i"},
+          "target": {"a/b": "d", "f/g":  "i"},
+          "expected": [
+            { "op": "replace", "path": "/a~1b", "value": "d" },
+            { "op": "remove", "path":"/e~1f" },
+            { "op": "add", "path":"/f~1g", "value":"i" }
+          ]
         }
 ]


### PR DESCRIPTION
To fix the issue 169 referenced at https://github.com/eclipse-ee4j/jsonp/issues/169, this commit change the method diffObject in JsonPatchImpl.java:224.

Before to add the key in operation patch, this code encode it as required by RFC6901 - JsonPointer.

Signed-off-by: dbehetre <dylan.behetre@capgemini.com>