### PR TITLE
Fixes #146: Avoid using exceptions for flow control in JsonObject implementation

### DIFF
--- a/impl/src/main/java/org/glassfish/json/JsonObjectBuilderImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonObjectBuilderImpl.java
@@ -235,9 +235,10 @@ class JsonObjectBuilderImpl implements JsonObjectBuilder {
 
         @Override
         public String getString(String name, String defaultValue) {
-            try {
-                return getString(name);
-            } catch (Exception e) {
+            JsonValue value = get(name);
+            if (value instanceof JsonString) {
+                return ((JsonString) value).getString();
+            } else {
                 return defaultValue;
             }
         }
@@ -249,9 +250,10 @@ class JsonObjectBuilderImpl implements JsonObjectBuilder {
 
         @Override
         public int getInt(String name, int defaultValue) {
-            try {
-                return getInt(name);
-            } catch (Exception e) {
+            JsonValue value = get(name);
+            if (value instanceof JsonNumber) {
+                return ((JsonNumber) value).intValue();
+            } else {
                 return defaultValue;
             }
         }
@@ -272,9 +274,12 @@ class JsonObjectBuilderImpl implements JsonObjectBuilder {
 
         @Override
         public boolean getBoolean(String name, boolean defaultValue) {
-            try {
-                return getBoolean(name);
-            } catch (Exception e) {
+            JsonValue value = get(name);
+            if (value == JsonValue.TRUE) {
+                return true;
+            } else if (value == JsonValue.FALSE) {
+                return false;
+            } else {
                 return defaultValue;
             }
         }

--- a/impl/src/main/java/org/glassfish/json/JsonObjectBuilderImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonObjectBuilderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/tests/src/test/java/org/glassfish/json/tests/JsonObjectTest.java
+++ b/tests/src/test/java/org/glassfish/json/tests/JsonObjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/tests/src/test/java/org/glassfish/json/tests/JsonObjectTest.java
+++ b/tests/src/test/java/org/glassfish/json/tests/JsonObjectTest.java
@@ -48,6 +48,39 @@ public class JsonObjectTest extends TestCase {
         assertEquals(person1, person2);
     }
 
+    public void testGetStringOrDefault() throws Exception {
+        JsonObject object = Json.createObjectBuilder()
+                .add("string", "value")
+                .add("number", 25)
+                .add("boolean", false)
+                .build();
+        assertEquals("value", object.getString("string", "default"));
+        assertEquals("default", object.getString("missing", "default"));
+        assertEquals("default", object.getString("number", "default"));
+    }
+
+    public void testGetIntOrDefault() throws Exception {
+        JsonObject object = Json.createObjectBuilder()
+                .add("string", "value")
+                .add("number", 25)
+                .add("boolean", false)
+                .build();
+        assertEquals(25, object.getInt("number", 10));
+        assertEquals(10, object.getInt("missing", 10));
+        assertEquals(10, object.getInt("string", 10));
+    }
+
+    public void testGetBooleanOrDefault() throws Exception {
+        JsonObject object = Json.createObjectBuilder()
+                .add("string", "value")
+                .add("number", 25)
+                .add("boolean", false)
+                .build();
+        assertFalse(object.getBoolean("boolean", true));
+        assertTrue(object.getBoolean("missing", true));
+        assertTrue(object.getBoolean("string", true));
+    }
+
     static void testPerson(JsonObject person) {
         assertEquals(5, person.size());
         assertEquals("John", person.getString("firstName"));


### PR DESCRIPTION
Exceptions by default will fill stacktraces which is very expensive
particularly when performed in a tight loop or in places with deep
stacks (such as on webservers). Replace there use within the variants
of getString, getInt and getBoolean which apply a default value. The
two exceptions which could previously be thrown were null pointers and
class cast which are now both handled using an instanceof check

Bug: https://github.com/eclipse-ee4j/jsonp/issues/146