### PR TITLE
fix doc status in dev/release version

### DIFF
--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -27,7 +27,7 @@
     <groupId>jakarta.json</groupId>
     <artifactId>jakarta.json-spec</artifactId>
     <packaging>pom</packaging>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
     <name>Jakarta JSON Processing Specification</name>
 
     <properties>

--- a/spec/src/main/asciidoc/license-efsl.adoc
+++ b/spec/src/main/asciidoc/license-efsl.adoc
@@ -4,7 +4,12 @@ Specification: {doctitle}
 
 Version: {revnumber}
 
+ifeval::["{revremark}" != ""]
 Status: {revremark}
+endif::[]
+ifeval::["{revremark}" == ""]
+Status: Final Release
+endif::[]
 
 Release: {revdate}
 ....


### PR DESCRIPTION
final release should not contain "DRAFT" in the header/footer etc. Also specs do not use "micro" version