### PR TITLE
Issue #190 - avoid writing newline before first object/array

### DIFF
--- a/impl/src/main/java/org/glassfish/json/JsonGeneratorImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonGeneratorImpl.java
@@ -487,6 +487,10 @@ class JsonGeneratorImpl implements JsonGenerator {
         currentContext.first = false;
     }
 
+    protected boolean inNone() {
+        return currentContext.scope == Scope.IN_NONE;
+    }
+
     boolean isCommaAllowed() {
         return !currentContext.first && currentContext.scope != Scope.IN_FIELD;
     }

--- a/impl/src/main/java/org/glassfish/json/JsonPrettyGeneratorImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonPrettyGeneratorImpl.java
@@ -88,7 +88,7 @@ public class JsonPrettyGeneratorImpl extends JsonGeneratorImpl {
     @Override
     protected void writeComma() {
         super.writeComma();
-        if (isCommaAllowed()) {
+        if (isCommaAllowed() && !inNone()) {
             writeChar('\n');
             writeIndent();
         }

--- a/impl/src/test/java/org/glassfish/json/tests/JsonGeneratorTest.java
+++ b/impl/src/test/java/org/glassfish/json/tests/JsonGeneratorTest.java
@@ -225,7 +225,7 @@ public class JsonGeneratorTest extends TestCase {
         generator.close();
         writer.close();
 
-        BufferedReader reader = new BufferedReader(new StringReader(writer.toString().trim()));
+        BufferedReader reader = new BufferedReader(new StringReader(writer.toString()));
         int numberOfLines = 0;
         String line;
         while ((line = reader.readLine()) != null) {


### PR DESCRIPTION
1. Added a protected inNone() method to JsonGeneratorImpl so that
subclasses can determine when we are in the outermost scope. I'm not
attached to the name.

2. Added a check to the if statement in
JsonPrettyGeneratorImpl.writeComma() to avoid writing the newline and
indentation when we're in the root context.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>