### PR TITLE
Fix warning in API

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -25,10 +25,6 @@
         <artifactId>project</artifactId>
         <version>1.0.6</version>
     </parent>
-    
-    <prerequisites>
-        <maven>3.3.1</maven>
-    </prerequisites>
 
     <groupId>jakarta.json</groupId>
     <artifactId>jakarta.json-api</artifactId>
@@ -235,6 +231,26 @@ Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">
                         <Specification-Vendor>Eclipse Foundation</Specification-Vendor>
                     </instructions>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M3</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.3.1</version>
+                                </requireMavenVersion>
+                            </rules>    
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
         <pluginManagement>


### PR DESCRIPTION
There is a warning in the API that suggests to use maven-enforcer-plugin. This PR gets rid of that warning.

> [WARNING] The project jakarta.json:jakarta.json-api:jar:2.0.0-SNAPSHOT uses prerequisites which is only intended for maven-plugin projects but not for non maven-plugin projects. For such purposes you should use the maven-enforcer-plugin. See https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html

