### PR TITLE
Remove duplicated plugin, set up just above

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -147,10 +147,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                     <docfilessubdirs>true</docfilessubdirs>


### PR DESCRIPTION
Fixes:
```
[WARNING] Some problems were encountered while building the effective model for jakarta.json:jakarta.json-api:bundle:2.0.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-source-plugin @ line 149, column 21
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
```
as seen on [last master on travis](https://travis-ci.org/eclipse-ee4j/jsonp/jobs/652082421#L459)