### PR TITLE
Parent is not relatively reachable for this project

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -24,6 +24,7 @@
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
         <version>1.0.6</version>
+        <relativePath/>
     </parent>
 
     <groupId>jakarta.json</groupId>


### PR DESCRIPTION
Fixes warning:
```
[WARNING] 'parent.relativePath' of POM jakarta.json:jakarta.json-api:2.0.0-SNAPSHOT (.../jsonp/api/pom.xml) points at org.glassfish:json instead of org.eclipse.ee4j:project, please verify your project structure @ line 23, column 13
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
```
as seen on [last master on travis](https://travis-ci.org/eclipse-ee4j/jsonp/jobs/652082421#L460)