### PR TITLE
#181: NullPointerException is thrown when op is not present in JSON Patch

### DIFF
--- a/impl/src/main/java/org/glassfish/json/JsonMessages.java
+++ b/impl/src/main/java/org/glassfish/json/JsonMessages.java
@@ -257,6 +257,10 @@ final class JsonMessages {
         return localize("patch.member.missing", operation, member);
     }
 
+    static String PATCH_OPERATION_MISSING() {
+        return localize("patch.operation.missing");
+    }
+
 
     private static String localize(String key, Object ... args) {
         try {

--- a/impl/src/main/java/org/glassfish/json/JsonPatchImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonPatchImpl.java
@@ -150,7 +150,11 @@ public class JsonPatchImpl implements JsonPatch {
 
         JsonPointer pointer = getPointer(operation, "path");
         JsonPointer from;
-        switch (Operation.fromOperationName(operation.getString("op"))) {
+        JsonString op = operation.getJsonString("op");
+        if (op == null) {
+            throw new JsonException(JsonMessages.PATCH_OPERATION_MISSING());
+        }
+        switch (Operation.fromOperationName(op.getString())) {
             case ADD:
                 return pointer.add(target, getValue(operation));
             case REPLACE:

--- a/impl/src/main/resources/org/glassfish/json/messages.properties
+++ b/impl/src/main/resources/org/glassfish/json/messages.properties
@@ -87,3 +87,4 @@ patch.move.target.null=The ''{0}'' path of the patch operation ''move'' does not
 patch.test.failed=The JSON Patch operation ''test'' failed for path ''{0}'' and value ''{1}''
 patch.illegal.operation=Illegal value for the op member of the JSON Patch operation: ''{0}''
 patch.member.missing=The JSON Patch operation ''{0}'' must contain a ''{1}'' member
+patch.operation.missing=The JSON Patch must contain ''op'' member


### PR DESCRIPTION
Fixes #181 

Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>