### PR TITLE
Support reading/writing values in JSON strings without java.util.String

### DIFF
--- a/impl/src/main/java/org/eclipse/jsonp/JsonParserImpl.java
+++ b/impl/src/main/java/org/eclipse/jsonp/JsonParserImpl.java
@@ -173,7 +173,7 @@ public class JsonParserImpl implements JsonParser {
                 return getObject(new JsonObjectBuilderImpl(bufferPool));
             case KEY_NAME:
             case VALUE_STRING:
-                return new JsonStringImpl(getString());
+                return new JsonStringImpl(getChars());
             case VALUE_NUMBER:
                 if (isDefinitelyInt()) {
                     return JsonNumberImpl.getJsonNumber(getInt());
@@ -320,6 +320,15 @@ public class JsonParserImpl implements JsonParser {
         }
         throw parsingException(JsonToken.EOF, "[CURLYOPEN, SQUAREOPEN, STRING, NUMBER, TRUE, FALSE, NULL, SQUARECLOSE]");
     }
+    
+    private CharSequence getChars() {
+      if (currentEvent == Event.KEY_NAME || currentEvent == Event.VALUE_STRING
+              || currentEvent == Event.VALUE_NUMBER) {
+          return tokenizer.getChars();
+      }
+      throw new IllegalStateException(
+              JsonMessages.PARSER_GETSTRING_ERR(currentEvent));
+  }
 
     private JsonObject getObject(JsonObjectBuilder builder) {
         while(hasNext()) {

--- a/impl/src/main/java/org/eclipse/jsonp/JsonStringImpl.java
+++ b/impl/src/main/java/org/eclipse/jsonp/JsonStringImpl.java
@@ -25,15 +25,15 @@ import jakarta.json.JsonString;
  */
 final class JsonStringImpl implements JsonString {
 
-    private final String value;
+    private final CharSequence value;
 
-    JsonStringImpl(String value) {
+    JsonStringImpl(CharSequence value) {
         this.value = value;
     }
 
     @Override
     public String getString() {
-        return value;
+        return value.toString();
     }
 
     @Override

--- a/impl/src/main/java/org/eclipse/jsonp/JsonTokenizer.java
+++ b/impl/src/main/java/org/eclipse/jsonp/JsonTokenizer.java
@@ -24,6 +24,7 @@ import jakarta.json.stream.JsonParser;
 import jakarta.json.stream.JsonParsingException;
 import java.io.*;
 import java.math.BigDecimal;
+import java.nio.CharBuffer;
 import java.util.Arrays;
 
 import jakarta.json.stream.JsonParser.Event;
@@ -508,6 +509,10 @@ final class JsonTokenizer implements Closeable {
 
     String getValue() {
         return new String(buf, storeBegin, storeEnd-storeBegin);
+    }
+    
+    CharSequence getChars() {
+      return CharBuffer.wrap(buf, storeBegin, storeEnd-storeBegin);
     }
 
     BigDecimal getBigDecimal() {


### PR DESCRIPTION
When dealing with sensitive information serialized within JSON, it is often important/necessary to transport that information in objects which can be removed from the heap (ie. via overwriting their content) when their useful life has expired.

This PR makes it possible, when making use of JsonString and the read/write methods which make use of it, to use generic CharSequence objects backed by the implementation of the caller's choice so that the data structures can be cleared when no longer needed.

This, admittedly, isn't as flexible on the read side as it is when writing (since JsonString doesn't offer facilities for clearing) so it would be up to the application making use of this library to identify the type of the underlying CharSequence and clear it appropriately.  If the API could be enhanced to better accommodate the needs described above, that would be helpful, but this at least provides a means for transporting sensitive data in a manner which can be purged without making use of illegal/unsafe reflection on String objects.