### PR TITLE
Json.createObjectBuilder(Map) has impractical type bounds

### DIFF
--- a/api/src/main/java/jakarta/json/Json.java
+++ b/api/src/main/java/jakarta/json/Json.java
@@ -299,7 +299,7 @@ public final class Json {
      *
      * @since 1.1
      */
-    public static JsonObjectBuilder createObjectBuilder(Map<String, Object> map) {
+    public static JsonObjectBuilder createObjectBuilder(Map<String, ?> map) {
         return JsonProvider.provider().createObjectBuilder(map);
     }
 

--- a/api/src/main/java/jakarta/json/spi/JsonProvider.java
+++ b/api/src/main/java/jakarta/json/spi/JsonProvider.java
@@ -253,7 +253,7 @@ public abstract class JsonProvider {
      *
      * @since 1.1
      */
-    public JsonObjectBuilder createObjectBuilder(Map<String, Object> map) {
+    public JsonObjectBuilder createObjectBuilder(Map<String, ?> map) {
         throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
Relates to https://github.com/eclipse-ee4j/jsonp/issues/168