### PR TITLE
remove garbage character between output and source

### DIFF
--- a/api/src/main/javadoc/overview.html
+++ b/api/src/main/javadoc/overview.html
@@ -92,7 +92,7 @@ for more details.
 <a href="jakarta.json/jakarta/json/JsonReader.html#JsonReaderExample1">This example</a> shows
 how to read and create an empty {@code JsonArray} model using the interface
 {@code JsonReader}. Similarly, these object models can be written to an output
-source (such as {@link java.io.OutputStream} or {@link java.io.Writer}) using
+source (such as {@link java.io.OutputStream} or {@link java.io.Writer}) using
 the class {@link jakarta.json.JsonWriter}.
 <a href="jakarta.json/jakarta/json/JsonWriter.html#JsonWriterExample1">This example</a> shows
 how to write an empty {@code JsonObject} model using the interface

--- a/api/src/main/javadoc/overview.html
+++ b/api/src/main/javadoc/overview.html
@@ -1,7 +1,7 @@
 <html>
 <!--
 
-    Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2013, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at


### PR DESCRIPTION
There is an unreadable character in the following line:

```
Similarly, these object models can be written to an output
source (such as {@link java.io.OutputStream} or {@link java.io.Writer}) using
the class {@link jakarta.json.JsonWriter}.
```

Signed-off-by: Kenji Kazumura <kzr@fujitsu.com>